### PR TITLE
Ensure that word break occurs at word boundary and set the key value align to top.

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -70,7 +70,7 @@
 
 .data-row .key-value-wrapper {
   display: flex;
-  align-items: center;
+  align-items: top;
 }
 
 .data-row .key {
@@ -181,7 +181,7 @@
 }
 
 .data-row .value .value-data {
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .show-data-types .data-row .value .type {


### PR DESCRIPTION
This PR ensures that word break occurs at word boundary and set the key value align to top.

References andypf/json-viewer#18.

**Before**
![{E5BE26C2-3C09-4338-9ABD-B673A9FE0C78}](https://github.com/user-attachments/assets/3632c256-e8e4-48d8-b76e-8766d33123b6)

**After**
![{121200C4-9002-461A-A07A-02AA7B642CC1}](https://github.com/user-attachments/assets/b2c1277f-261b-42ce-97a9-d872f99305e7)